### PR TITLE
Update tfprocess.py for TensorFlow 2.4+

### DIFF
--- a/move_prediction/maia_chess_backend/maia/tfprocess.py
+++ b/move_prediction/maia_chess_backend/maia/tfprocess.py
@@ -120,7 +120,7 @@ class TFProcess:
         tf.config.experimental.set_visible_devices(gpus[self.cfg['gpu']], 'GPU')
         tf.config.experimental.set_memory_growth(gpus[self.cfg['gpu']], True)
         if self.model_dtype == tf.float16:
-            tf.keras.mixed_precision.experimental.set_policy('mixed_float16')
+            tf.keras.mixed_precision.set_global_policy('mixed_float16')
 
         self.global_step = tf.Variable(0, name='global_step', trainable=False, dtype=tf.int64)
 
@@ -147,7 +147,7 @@ class TFProcess:
         self.optimizer = tf.keras.optimizers.SGD(learning_rate=lambda: self.active_lr, momentum=0.9, nesterov=True)
         self.orig_optimizer = self.optimizer
         if self.loss_scale != 1:
-            self.optimizer = tf.keras.mixed_precision.experimental.LossScaleOptimizer(self.optimizer, self.loss_scale)
+            self.optimizer = tf.keras.mixed_precision.LossScaleOptimizer(self.optimizer)
         def correct_policy(target, output):
             output = tf.cast(output, tf.float32)
             # Calculate loss on policy head


### PR DESCRIPTION
While trying to train my own model, I happen to found an error within `tfprocess.py` that made `train_maia.py` not work if you're using a TensorFlow version that is greater than 2.4.

The reason is that `tf.keras.mixed_precision.experimental` API had been removed with the introduction of `tf.keras.mixed_precision` in TensorFlow 2.4+.

To fix this, I changed two lines of code. 

`tf.keras.mixed_precision.experimental.set_policy('mixed_float16')`, which can be found in Line 123, was changed to `tf.keras.mixed_precision.set_global_policy('mixed_float16')`.

`self.optimizer = tf.keras.mixed_precision.experimental.LossScaleOptimizer(self.optimizer, self.loss_scale)`, which can be found in Line 150, was changed to `self.optimizer = tf.keras.mixed_precision.LossScaleOptimizer(self.optimizer)`.